### PR TITLE
ci: add cooldown to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,17 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
   - package-ecosystem: npm
     directory: "/javascript"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
   - package-ecosystem: bundler
     directory: "/ruby"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Adds a 7-day cooldown to each ecosystem block in `.github/dependabot.yml` so Dependabot doesn't open a PR for a package/action version the instant it's published — gives the community time to catch a bad or malicious release first.

Closes the Bastion `dependabot-missing-cooldown` findings (x3, one per ecosystem block).